### PR TITLE
Added SDA, SCL pin options, added examples, removed static

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,43 @@ Assuming the following wiring (and powered by USB):
 | GP3  | SCL     |
 
 ```js
-const LCD = require('lcd');
+const LCD = require('i2c-lcd');
 const lcd = new LCD();
 lcd.begin();
 ```
 
 ## Examples
-Coming soon.
+
+### Adding text to LCD
+
+This can be done via the `lcd.print(string)` function
+
+```js
+const LCD = require("./lcd")
+let lcd = new LCD()
+
+lcd.begin();
+
+lcd.print("Hello, World!")
+```
+
+### Create custom symbols
+
+Making a symbol is very easy!
+
+First you must load the symbol to the LCD, you can do this via the `lcd.createChar(id, symbol)` function
+
+```js
+const LCD = require("i2c-lcd")
+let lcd = new LCD()
+
+lcd.begin();
+
+lcd.createChar(1, [0,10,10,0,17,14,0,0]) // Happy face data
+lcd.createChar(2, [0,10,0,14,17,17,17,14]) // Shocked face data
+
+lcd.print(lcd.getChar(1)+lcd.getChar(2)) // Happy face | Shocked face
+```
 
 ## API - Class: LCD
 ### Constructor
@@ -35,6 +65,8 @@ Coming soon.
 |-----------|---------|--------------------------------|
 | busNumber | 1       | bus number of the i2c device   |
 | address   | 0x27    | address of the i2c device      |
+| sda       | 26      | SDA pin of the i2c device      |
+| scl       | 27      | SCL pin of the i2c device      |
 | cols      | 16      | character width of the display |
 | rows      | 2       | number of lines in the display  |
 ### Properties (read-only)
@@ -42,6 +74,10 @@ Coming soon.
     - the bus number declared when instantiating the LCD object
 - `address`
     - the i2c address declared when instantiating the LCD object
+- `sda`
+    - the i2c sda pin declared when instantiating the LCD object
+- `scl`
+    - the i2c scl pin declared when instantiating the LCD object
 - `cols`
     - the number of characters width declared when instantiating the LCD object
 - `rows`
@@ -89,7 +125,6 @@ Coming soon.
     - the five least significant bits of each byte determine the pixels in that row
     - to display a custom character on the screen, use `print(LCD.getChar(id))`
     - for more information on creating characters, check out [this tool](https://www.quinapalus.com/hd44780udg.html)
-### Static Methods
 - `getChar(id)`
     - gets the custom character stored at the specified id
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Assuming the following wiring (and powered by USB):
 | GP3  | SCL     |
 
 ```js
-const { LCD } = require('lcd');
+const LCD = require('lcd');
 const lcd = new LCD();
 lcd.begin();
 ```

--- a/index.js
+++ b/index.js
@@ -249,7 +249,7 @@ module.exports = class LCD {
         this.write(this.SETDDRAMADDR, this.displayPorts.CMD);
     }
 
-    static getChar(charId) {
+    getChar(charId) {
         return (String.fromCharCode(charId));
     }
 }

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 const {I2C} = require('i2c');
 
 module.exports = class LCD {
-    constructor(busNumber = 1, address = 0x27, cols = 16, rows = 2) {
+    constructor(busNumber = 1, address = 0x27, sda = 26, scl = 27, cols = 16, rows = 2) {
         this.displayPorts = { // unused display ports excluded
             E: 0x04,        
             CHR: 1,
@@ -43,6 +43,9 @@ module.exports = class LCD {
         this.ADDRESS = address;
         this.COLS = cols;
         this.ROWS = rows;
+        this.SDA = sda;
+        this.SCL = scl;
+
         this.I2C = null;
         this.BLINKING = false;
         this.CURSOR = false;
@@ -55,6 +58,14 @@ module.exports = class LCD {
 
     get address() {
         return this.ADDRESS;
+    }
+
+    get sda() {
+        return this.SDA;
+    }
+
+    get scl() {
+        return this.SCL;
     }
 
     get cols() {
@@ -86,7 +97,7 @@ module.exports = class LCD {
         if (this.BEGAN) {
             throw new Error('The LCD is already initialized.');
         }
-        this.I2C = new I2C(this.BUSNUMBER, { mode: I2C.MASTER });
+        this.I2C = new I2C(this.BUSNUMBER, { mode: I2C.MASTER, scl: this.SCL, sda: this.SDA });
         this.write4(0x33, this.displayPorts.CMD); // initialization
         this.write4(0x32, this.displayPorts.CMD); // initialization
         this.write4(0x06, this.displayPorts.CMD); // initialization


### PR DESCRIPTION
The main point of this PR is to add SDA and SCL pins as options when making the LCD class

I personally couldn't get the LCD to work without specifying the SDA/SCL pins, I would get a `Error: Device Write Error`

This also fixes the read me as the import for the module was wrong (same as #2 ) but mine also removes `{ LCD }` ( using `{ LCD }`, again didn't work for me)

I also removed the static method for `getChar` as it didn't make sense logically, at least for me.
- When you define a custom symbol, that symbol is written to the LCD
- When you use the symbol, you use convert the `ID` to a char code
- This charCode isn't actually the custom symbol, its an invalid char, the LCD itself sees that this is `0-7` and then pulls the custom symbol from its memory
- Making this a static function can confuse people, I think its better fit being a function in the class

I also added some examples to the read me, they aren't the best but its a start.